### PR TITLE
Initial release of apollo-fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change log
+
+### vNEXT
+
+### 0.0.0
+
+Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ### vNEXT
 
-### 0.0.0
+### 0.1.0
 
 Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### vNEXT
 
+### 0.2.0
+
+Adds alias `apolloFetch` for default call to `createApolloFetch`
+
 ### 0.1.0
 
 Initial release

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # apollo-fetch
 
-`apollo-fetch` is a lightweight fetch for GraphQL requests that supports the middleware and afterware to modify requests and responses.
+`apollo-fetch` is a lightweight client for GraphQL requests that supports middleware and afterware that modify requests and responses.
 
 By default `apollo-fetch` uses `isomorphic-fetch`, but you have the option of using a custom fetch function.
 
 # Usage
 
-Simple GraphQL query
+Simple GraphQL query:
 
 ```js
 import { createApolloFetch } from 'apollo-fetch'
 
-const uri = 'example.com/graphql';
+const uri = 'http://api.githunt.com/graphql';
 
 const query = `
   query sampleQuery(id: ID!) {
@@ -23,8 +23,8 @@ const query = `
 `
 const apolloFetch = createApolloFetch({ uri });
 
-apolloFetch({query})
-.then((result) => {
+apolloFetch({ query })
+.then( result => {
   // GraphQL data, GraphQL errors and GraphQL extensions
   const { data, error, extensions } = result;
 })
@@ -39,7 +39,7 @@ Middleware has access to the GraphQL query and the options passed to fetch.
 ```js
 import { createApolloFetch } from 'apollo-fetch'
 
-const uri = 'api.githunt.com/graphql';
+const uri = 'http://api.githunt.com/graphql';
 
 const query = `
   query sampleMutation(id: ID!) {
@@ -50,21 +50,23 @@ const query = `
   }
 `
 
-const apolloFetch = createApolloFetch({uri});
+const apolloFetch = createApolloFetch({ uri });
 
-apolloFetch.use({applyMiddleware: ({ request, options }, next) => {
-  if (!options.headers) {
-    options.headers = {};  // Create the headers object if needed.
-  }
-  options.headers['authorization'] = 'created token';
+apolloFetch.use([{
+  applyMiddleware: ({ request, options }, next) => {
+    if (!options.headers) {
+      options.headers = {};  // Create the headers object if needed.
+    }
+    options.headers['authorization'] = 'created token';
 
-  next();
-}});
+    next();
+  },
+}]);
 
 apolloFetch({ query })
 .then(result => {
-  // GraphQL data, errors, and extensions plus context from the server
-  const {data, error, extensions context} = result;
+  // GraphQL data, errors, and extensions
+  const { data, error, extensions } = result;
 })
 .catch(error => {
   //respond to a network error
@@ -77,18 +79,18 @@ The afterware has access to the raw reponse always and parsed response when the 
 ```js
 import { createApolloFetch } from 'apollo-fetch'
 
-const uri = 'example.com/graphql';
+const uri = 'http://api.githunt.com/graphql';
 
 const apolloFetch = createApolloFetch({ uri });
 
-apolloFetch.useAfter({
+apolloFetch.useAfter([{
   applyAfterware: ({ response }, next) => {
     if (response.status === 401) {
       logout();
     }
     next();
-  }
-});
+  },
+}]);
 
 apolloFetch({ query })
 .then(result => {

--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ apolloFetch.use([exampleWare1])
   .use([exampleWare5]);
 ```
 
+`apolloFetch` is an alias for an empty call to `createApolloFetch`
+
+```js
+import { apolloFetch } from `apollo-fetch`;
+
+//fetches a query from /graphql
+apolloFetch({ query }).then(...).catch(...)
+```
+
 
 # API
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,208 @@
+# apollo-fetch
+
+`apollo-fetch` is a lightweight fetch for GraphQL requests that supports the middleware and afterware to modify the request and response.
+
+By default, `apollo-fetch` uses `isomorphic-fetch` and provides the option of using a custom fetch function.
+
+In addition, `apollo-fetch` supports passing a context to the server and receiving a context.
+This context can be used by the middleware and afterware.
+
+# Usage
+
+Simple GraphQL query
+
+```js
+import { createApolloFetch } from 'apollo-fetch'
+
+const uri = 'example.com/graphql';
+
+const query = `
+  query sampleQuery(id: ID!) {
+    sample(id: $id) {
+      id,
+      name
+    }
+  }
+`
+
+createApolloFetch({uri})({query})
+.then((result) => {
+  // GraphQL data, GraphQL errors, GraphQL extensions, and possible context from the server
+  const {data, error, extensions, context} = result;
+})
+.catch((error) => {
+  //respond to a network error
+})
+```
+
+Simple GraphQL mutation with authentication middleware.
+Middleware has access to the GraphQL query and the options passed to fetch.
+
+```js
+import { createApolloFetch } from 'apollo-fetch'
+
+const uri = 'example.com/graphql';
+
+const query = `
+  query sampleMutation(id: ID!) {
+    addSample(id: $id) {
+      id,
+      name
+    }
+  }
+`
+
+const apolloFetch = createApolloFetch({uri});
+
+apolloFetch.use({applyMiddleware: ({request, options}, next) => {
+  if (!options.headers) {
+    options.headers = {};  // Create the headers object if needed.
+  }
+  options.headers['authorization'] = 'created token';
+
+  next();
+}});
+
+apolloFetch({query})
+.then((result) => {
+  // GraphQL data, errors, and extensions plus context from the server
+  const {data, error, extensions context} = result;
+})
+.catch((error) => {
+  //respond to a network error
+})
+```
+
+Afterware to check the response status and logout on a 401.
+The afterware has access to the raw reponse always and parsed response when the data is proper JSON.
+
+```js
+import { createApolloFetch } from 'apollo-fetch'
+
+const uri = 'example.com/graphql';
+
+const apolloFetch = createApolloFetch({uri});
+
+apolloFetch.useAfter({
+  applyAfterware: ({ response }, next) => {
+    if (response.status === 401) {
+      logout();
+    }
+    next();
+  }
+});
+
+apolloFetch({query})
+.then((result) => {
+  // GraphQL data, errors, and extensions plus context from the server
+  const {data, error, extensions context} = result;
+})
+.catch((error) => {
+  //respond to a network error
+})
+```
+
+Middleware and Afterware can be chained together in any order:
+
+```js
+const apolloFetch = createApolloFetch();
+apolloFetch.use([exampleWare1])
+  .use([exampleWare2])
+  .useAfter([exampleWare3])
+  .useAfter([exampleWare4])
+  .use([exampleWare5]);
+```
+
+
+# API
+
+`createApolloFetch` is a factory for `ApolloFetch`, a fetch with middleware and afterware capabilities.
+
+```js
+createApolloFetch(options: FetchOptions): ApolloFetch
+
+FetchOptions {
+  uri?: string;
+  customFetch?: (request: RequestInfo, init: RequestInit) => Promise<Response>;
+}
+/* defaults:
+ * uri = '/graphql'
+ * customFetch = fetch from isomorphic-fetch
+ */
+```
+
+`ApolloFetch`, a fetch function with middleware and afterware capabilities.
+
+```js
+ApolloFetch {
+  (operation: GraphQLRequest): Promise<FetchResult>;
+  use: (middlewares: MiddlewareInterface[]) => ApolloFetch;
+  useAfter: (afterwares: AfterwareInterface[]) => ApolloFetch;
+}
+```
+
+`GraphQLRequest` is the argument to an `ApolloFetch` call
+
+```js
+GraphQLRequest {
+  query?: string;
+  variables?: object;
+  operationName?: string;
+  context?: object;
+}
+```
+
+`FetchResult` is the return value of an `ApolloFetch` call
+
+```js
+FetchResult {
+  data: any;
+  errors?: any;
+  extensions?: any;
+  context?: object;
+}
+```
+
+Middleware used by `ApolloFetch`
+
+```js
+MiddlewareInterface {
+  applyMiddleware(request: RequestAndOptions, next: Function): void;
+}
+
+RequestAndOptions {
+  request: GraphQLRequest;
+  options: RequestInit;
+}
+```
+
+Afterware used by `ApolloFetch`
+
+```js
+AfterwareInterface {
+  applyAfterware(response: ResponseAndOptions, next: Function): any;
+}
+
+ResponseAndOptions {
+  response: ParsedResponse;
+  options: RequestInit;
+}
+```
+
+`ParsedResponse` adds `raw`, the body from the .text() call on the fetch result, and `parsed`, the parsed JSON from `raw`, onto the regular Response from the fetch call.
+
+```js
+ParsedResponse extends Response {
+  raw: string;
+  parsed?: any;
+}
+```
+
+The error returned from a call to `ApolloFetch` is a normal error that contains the response, the raw response from .text(), a possible parse error.
+
+```js
+FetchError extends Error {
+  response: ParsedResponse;
+  raw: string;
+  parseError?: Error;
+}

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # apollo-fetch
 
-`apollo-fetch` is a lightweight fetch for GraphQL requests that supports the middleware and afterware to modify the request and response.
+`apollo-fetch` is a lightweight fetch for GraphQL requests that supports the middleware and afterware to modify requests and responses.
 
-By default, `apollo-fetch` uses `isomorphic-fetch` and provides the option of using a custom fetch function.
-
-In addition, `apollo-fetch` supports passing a context to the server and receiving a context.
-This context can be used by the middleware and afterware.
+By default `apollo-fetch` uses `isomorphic-fetch`, but you have the option of using a custom fetch function.
 
 # Usage
 
@@ -24,13 +21,14 @@ const query = `
     }
   }
 `
+const apolloFetch = createApolloFetch({ uri });
 
-createApolloFetch({uri})({query})
+apolloFetch({query})
 .then((result) => {
-  // GraphQL data, GraphQL errors, GraphQL extensions, and possible context from the server
-  const {data, error, extensions, context} = result;
+  // GraphQL data, GraphQL errors and GraphQL extensions
+  const { data, error, extensions } = result;
 })
-.catch((error) => {
+.catch(error => {
   //respond to a network error
 })
 ```
@@ -41,7 +39,7 @@ Middleware has access to the GraphQL query and the options passed to fetch.
 ```js
 import { createApolloFetch } from 'apollo-fetch'
 
-const uri = 'example.com/graphql';
+const uri = 'api.githunt.com/graphql';
 
 const query = `
   query sampleMutation(id: ID!) {
@@ -54,7 +52,7 @@ const query = `
 
 const apolloFetch = createApolloFetch({uri});
 
-apolloFetch.use({applyMiddleware: ({request, options}, next) => {
+apolloFetch.use({applyMiddleware: ({ request, options }, next) => {
   if (!options.headers) {
     options.headers = {};  // Create the headers object if needed.
   }
@@ -63,12 +61,12 @@ apolloFetch.use({applyMiddleware: ({request, options}, next) => {
   next();
 }});
 
-apolloFetch({query})
-.then((result) => {
+apolloFetch({ query })
+.then(result => {
   // GraphQL data, errors, and extensions plus context from the server
   const {data, error, extensions context} = result;
 })
-.catch((error) => {
+.catch(error => {
   //respond to a network error
 })
 ```
@@ -81,7 +79,7 @@ import { createApolloFetch } from 'apollo-fetch'
 
 const uri = 'example.com/graphql';
 
-const apolloFetch = createApolloFetch({uri});
+const apolloFetch = createApolloFetch({ uri });
 
 apolloFetch.useAfter({
   applyAfterware: ({ response }, next) => {
@@ -92,12 +90,12 @@ apolloFetch.useAfter({
   }
 });
 
-apolloFetch({query})
-.then((result) => {
-  // GraphQL data, errors, and extensions plus context from the server
-  const {data, error, extensions context} = result;
+apolloFetch({ query })
+.then(result => {
+  // GraphQL data, errors, and extensions from the server
+  const { data, error, extensions } = result;
 })
-.catch((error) => {
+.catch(error => {
   //respond to a network error
 })
 ```
@@ -116,7 +114,7 @@ apolloFetch.use([exampleWare1])
 
 # API
 
-`createApolloFetch` is a factory for `ApolloFetch`, a fetch with middleware and afterware capabilities.
+`createApolloFetch` is a factory for `ApolloFetch`, a fetch function with middleware and afterware capabilities.
 
 ```js
 createApolloFetch(options: FetchOptions): ApolloFetch
@@ -189,7 +187,7 @@ ResponseAndOptions {
 }
 ```
 
-`ParsedResponse` adds `raw`, the body from the .text() call on the fetch result, and `parsed`, the parsed JSON from `raw`, onto the regular Response from the fetch call.
+`ParsedResponse` adds `raw` (the body from the `.text()` call) to the fetch result, and `parsed` (the parsed JSON from `raw`) to the regular Response from the fetch call.
 
 ```js
 ParsedResponse extends Response {
@@ -198,7 +196,7 @@ ParsedResponse extends Response {
 }
 ```
 
-The error returned from a call to `ApolloFetch` is a normal error that contains the response, the raw response from .text(), a possible parse error.
+Errors returned from a call to `ApolloFetch` are normal errors that contain the parsed response, the raw response from .text(), and a possible parse error.
 
 ```js
 FetchError extends Error {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-fetch",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Lightweight implementation of fetch for GraphQL requests",
   "author": "Evans Hauser <evanshauser@gmail.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "chai-as-promised": "^7.0.0",
     "fetch-mock": "^5.11.0",
     "istanbul": "^0.4.4",
+    "graphql": "^0.10.3",
+    "graphql-tag": "^2.4.2",
     "lodash": "^4.17.4",
     "mocha": "^3.2.0",
     "remap-istanbul": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-fetch",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Lightweight implementation of fetch for GraphQL requests",
   "author": "Evans Hauser <evanshauser@gmail.com>",
   "contributors": [

--- a/src/apollo-fetch.ts
+++ b/src/apollo-fetch.ts
@@ -167,3 +167,5 @@ export function createApolloFetch(params: FetchOptions = {}): ApolloFetch {
   return apolloFetch as ApolloFetch;
 }
 
+const apolloFetch = createApolloFetch();
+export { apolloFetch };

--- a/src/apollo-fetch.ts
+++ b/src/apollo-fetch.ts
@@ -71,11 +71,11 @@ export function createApolloFetch(params: FetchOptions = {}): ApolloFetch {
     try {
       body = JSON.stringify(request);
     } catch (e) {
-      throw new Error(`Network request failed with status ${response.status} - "${response.statusText}"`);
+      throw new Error(`Network request failed. Payload is not serizable: ${e.message}`);
     }
 
     const opts = {
-      body: body,
+      body,
       method: 'POST',
       ...options,
       headers: {
@@ -121,8 +121,8 @@ export function createApolloFetch(params: FetchOptions = {}): ApolloFetch {
             //pass parsed raw response onto afterware
             return <ParsedResponse>{ ...response, raw, parsed: null };
           }
-        })
-        .catch( error => throwHttpError(response, error)),
+        }),
+        //.catch() this should never happen: https://developer.mozilla.org/en-US/docs/Web/API/Body/text
       )
       .then(response => applyAfterwares({
         response,

--- a/src/apollo-fetch.ts
+++ b/src/apollo-fetch.ts
@@ -1,0 +1,162 @@
+import {
+  FetchResult,
+  RequestAndOptions,
+  ResponseAndOptions,
+  AfterwareInterface,
+  MiddlewareInterface,
+  FetchOptions,
+  ApolloFetch,
+  ParsedResponse,
+  GraphQLRequest,
+} from './types';
+import 'isomorphic-fetch';
+
+export function createApolloFetch(params: FetchOptions = {}): ApolloFetch {
+  const {uri, customFetch} = params;
+
+  const _uri = uri || '/graphql';
+  const _middlewares = [];
+  const _afterwares = [];
+
+  const applyMiddlewares = (requestAndOptions: RequestAndOptions): Promise<RequestAndOptions> => {
+    return new Promise((resolve, reject) => {
+      const { request, options } = requestAndOptions;
+      const queue = (funcs: MiddlewareInterface[], scope: any) => {
+        const next = () => {
+          if (funcs.length > 0) {
+            const f = funcs.shift();
+            if (f) {
+              f.applyMiddleware.apply(scope, [{ request, options }, next]);
+            }
+          } else {
+            resolve({
+              request,
+              options,
+            });
+          }
+        };
+        next();
+      };
+
+      queue([..._middlewares], this);
+    });
+  };
+
+
+  const applyAfterwares = ({response, options}: ResponseAndOptions): Promise<ResponseAndOptions> => {
+    return new Promise((resolve, reject) => {
+      // Declare responseObject so that afterware can mutate it.
+      const responseObject = {response, options};
+      const queue = (funcs: AfterwareInterface[], scope: any) => {
+        const next = () => {
+          if (funcs.length > 0) {
+            const f = funcs.shift();
+            if (f) {
+              f.applyAfterware.apply(scope, [responseObject, next]);
+            }
+          } else {
+            resolve(responseObject);
+          }
+        };
+        next();
+      };
+
+      // iterate through afterwares using next callback
+      queue([..._afterwares], this);
+    });
+  };
+
+  const callFetch = ({request, options}) => {
+    const opts = {
+      body: JSON.stringify(request),
+      method: 'POST',
+      ...options,
+      headers: {
+        Accept: '*/*',
+        'Content-Type': 'application/json',
+        ...(options.headers as { [headerName: string]: string }),
+      },
+    };
+    return customFetch ? customFetch(_uri, opts) : fetch(_uri, opts);
+  };
+
+  const throwHttpError = (response, error) => {
+    let httpError;
+    if (response && response.status >= 300) {
+      httpError = new Error(`Network request failed with status ${response.status} - "${response.statusText}"`);
+    } else {
+      httpError = new Error(`Network request failed to return valid JSON`);
+    }
+    (httpError as any).response = response;
+    (httpError as any).raw = response.raw;
+    (httpError as any).parseError = error;
+
+    throw httpError;
+  };
+
+  let apolloFetch: ApolloFetch = <ApolloFetch>Object.assign(
+    function (request: GraphQLRequest): Promise<FetchResult> {
+      const options = {};
+      let parseError;
+
+      return applyMiddlewares({
+        request,
+        options,
+      })
+      .then(callFetch)
+      .then((response) => response.text().then((raw) => {
+          try {
+            const parsed = JSON.parse(raw);
+            return <ParsedResponse>{ ...response, raw, parsed };
+          } catch (e) {
+            parseError = e;
+
+            //pass parsed raw response onto afterware
+            return <ParsedResponse>{ ...response, raw, parsed: null };
+          }
+        })
+        .catch((error) => throwHttpError(response, error)),
+      )
+      .then(response => applyAfterwares({
+        response,
+        options,
+      }))
+      .then(({ response }) => {
+        if (response.parsed) {
+          return { ...response.parsed };
+        } else {
+          throwHttpError(response, parseError);
+        }
+      });
+    },
+    {
+      use: (middlewares: MiddlewareInterface[]) => {
+        middlewares.map((middleware) => {
+          if (typeof middleware.applyMiddleware === 'function') {
+            _middlewares.push(middleware);
+          } else {
+            throw new Error('Middleware must implement the applyMiddleware function');
+          }
+        });
+
+        return apolloFetch;
+      },
+      useAfter: (afterwares: AfterwareInterface[]) => {
+        afterwares.map((afterware) => {
+          if (typeof afterware.applyAfterware === 'function') {
+            _afterwares.push(afterware);
+          } else {
+            throw new Error('Afterware must implement the applyAfterware function');
+          }
+        });
+
+        return apolloFetch;
+      },
+      _middlewares, //Added as hooks for testing
+      _afterwares,
+    },
+  );
+
+  return apolloFetch as ApolloFetch;
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,14 @@
+import {
+  ApolloFetch,
+  GraphQLRequest,
+} from './types';
+
+import {
+  createApolloFetch,
+} from './apollo-fetch';
+
+export {
+  createApolloFetch,
+  ApolloFetch,
+  GraphQLRequest,
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,47 @@
+export interface ApolloFetch {
+  (operation: GraphQLRequest): Promise<FetchResult>;
+  use: (middlewares: MiddlewareInterface[]) => ApolloFetch;
+  useAfter: (afterwares: AfterwareInterface[]) => ApolloFetch;
+}
+
+export interface GraphQLRequest {
+  query?: string;
+  variables?: object;
+  operationName?: string;
+  context?: object;
+}
+
+export interface FetchResult {
+  data: any;
+  errors?: any;
+  extensions?: any;
+  context?: object;
+}
+
+export interface AfterwareInterface {
+  applyAfterware(response: ResponseAndOptions, next: Function): any;
+}
+
+export interface MiddlewareInterface {
+  applyMiddleware(request: RequestAndOptions, next: Function): void;
+}
+
+export interface RequestAndOptions {
+  request: GraphQLRequest;
+  options: RequestInit;
+}
+
+export interface ParsedResponse extends Response {
+  raw: string;
+  parsed?: any;
+}
+
+export interface ResponseAndOptions {
+  response: ParsedResponse;
+  options: RequestInit;
+}
+
+export interface FetchOptions {
+  uri?: string;
+  customFetch?: (request: RequestInfo, init: RequestInit) => Promise<Response>;
+}

--- a/tests/apollo-fetch.ts
+++ b/tests/apollo-fetch.ts
@@ -155,15 +155,14 @@ describe('apollo-fetch', () => {
     });
   });
 
-  it('should call fetch with correct url', (done) => {
-    const uri = 'test';
-    const fetcher = createApolloFetch({uri});
+  const callAndCheckFetch = (uri, fetcher, numCalls, done) => {
     const result = fetcher({query: print(sampleQuery)});
+
     result.then((response) => {
       //correct response
       assert.deepEqual(response, JSON.parse(data));
       //single call
-      assert.deepEqual(fetchMock.calls(uri).length, 1);
+      assert.deepEqual(fetchMock.calls(uri).length, numCalls);
 
       assert.deepEqual(fetchMock.lastCall(uri)[0], uri);
       const options = fetchMock.lastCall(uri)[1];
@@ -173,6 +172,22 @@ describe('apollo-fetch', () => {
       assert.deepEqual(body.query, print(sampleQuery));
       done();
     });
+
+  };
+
+  it('should call fetch with correct arguments and result', (done) => {
+    const uri = 'test';
+    const fetcher = createApolloFetch({uri});
+    callAndCheckFetch(uri, fetcher, 1, done);
+  });
+
+  it('should make two successful requests', (done) => {
+    const uri = 'test';
+    const fetcher = createApolloFetch({uri});
+    const fetchWrapper = (callNumber, continuation) => callAndCheckFetch(uri, fetcher, callNumber, continuation);
+
+    fetchWrapper(1, () => fetchWrapper(2, done));
+
   });
 
   it('should pass an error onto the Promise', () => {

--- a/tests/apollo-fetch.ts
+++ b/tests/apollo-fetch.ts
@@ -155,14 +155,12 @@ describe('apollo-fetch', () => {
     });
   });
 
-  const callAndCheckFetch = (uri, fetcher, numCalls, done) => {
+  const callAndCheckFetch = (uri, fetcher) => {
     const result = fetcher({query: print(sampleQuery)});
 
-    result.then((response) => {
+    return result.then((response) => {
       //correct response
       assert.deepEqual(response, JSON.parse(data));
-      //single call
-      assert.deepEqual(fetchMock.calls(uri).length, numCalls);
 
       assert.deepEqual(fetchMock.lastCall(uri)[0], uri);
       const options = fetchMock.lastCall(uri)[1];
@@ -170,24 +168,21 @@ describe('apollo-fetch', () => {
       assert.deepEqual(options.method, 'POST');
       assert.deepEqual(options.headers, {Accept: '*/*', 'Content-Type': 'application/json'});
       assert.deepEqual(body.query, print(sampleQuery));
-      done();
     });
 
   };
 
-  it('should call fetch with correct arguments and result', (done) => {
+  it('should call fetch with correct arguments and result', () => {
     const uri = 'test';
     const fetcher = createApolloFetch({uri});
-    callAndCheckFetch(uri, fetcher, 1, done);
+    return callAndCheckFetch(uri, fetcher);
   });
 
-  it('should make two successful requests', (done) => {
+  it('should make two successful requests', () => {
     const uri = 'test';
     const fetcher = createApolloFetch({uri});
-    const fetchWrapper = (callNumber, continuation) => callAndCheckFetch(uri, fetcher, callNumber, continuation);
-
-    fetchWrapper(1, () => fetchWrapper(2, done));
-
+    return callAndCheckFetch(uri, fetcher)
+      .then(() => callAndCheckFetch(uri, fetcher));
   });
 
   it('should pass an error onto the Promise', () => {

--- a/tests/apollo-fetch.ts
+++ b/tests/apollo-fetch.ts
@@ -1,0 +1,496 @@
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import { isEqual } from 'lodash';
+import gql from 'graphql-tag';
+import { print } from 'graphql';
+import * as fetchMock from 'fetch-mock';
+import {
+  createApolloFetch,
+} from '../src/apollo-fetch';
+import {
+  RequestAndOptions,
+  ResponseAndOptions,
+} from '../src/types';
+
+chai.use(chaiAsPromised);
+
+const { assert, expect } = chai;
+
+const sampleQuery = gql`
+query SampleQuery {
+  stub{
+    id
+  }
+}
+`;
+
+describe('apollo-fetch', () => {
+  const postData = {hello: 'world', method: 'POST'};
+  const data = JSON.stringify({data: { hello: 'world' }});
+  const unparsableData = 'raw string';
+  const mockError = { throws: new TypeError('mock me') };
+  const swapiUrl = 'http://graphql-swapi.test/';
+  const missingUrl = 'http://does-not-exist.test/';
+
+  const unauthorizedUrl = 'http://unauthorized.test/';
+  const serviceUnavailableUrl = 'http://service-unavailable.test/';
+
+  const simpleQueryWithNoVars = gql`
+    query people {
+      allPeople(first: 1) {
+        people {
+          name
+        }
+      }
+    }
+  `;
+
+  const simpleQueryWithVar = gql`
+    query people($personNum: Int!) {
+      allPeople(first: $personNum) {
+        people {
+          name
+        }
+      }
+    }
+  `;
+
+  const simpleResult = {
+    data: {
+      allPeople: {
+        people: [
+          {
+            name: 'Luke Skywalker',
+          },
+        ],
+      },
+    },
+  };
+
+  const complexQueryWithTwoVars = gql`
+    query people($personNum: Int!, $filmNum: Int!) {
+      allPeople(first: $personNum) {
+        people {
+          name
+          filmConnection(first: $filmNum) {
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const complexResult = {
+    data: {
+      allPeople: {
+        people: [
+          {
+            name: 'Luke Skywalker',
+            filmConnection: {
+              edges: [
+                {
+                  node: {
+                    id: 'ZmlsbXM6MQ==',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  before(() => {
+
+    fetchMock.post('/graphql', data);
+    fetchMock.post('/raw', unparsableData);
+    fetchMock.post('begin:data', postData);
+    fetchMock.post('begin:error', mockError);
+    fetchMock.post('test', data);
+
+    fetchMock.post(swapiUrl, (url, opts) => {
+      const { query, variables } = JSON.parse((opts as RequestInit).body!.toString());
+
+      if (query === print(simpleQueryWithNoVars)) {
+        return simpleResult;
+      }
+
+      if (query === print(simpleQueryWithVar)
+          && isEqual(variables, { personNum: 1 })) {
+        return simpleResult;
+      }
+
+      if (query === print(complexQueryWithTwoVars)
+          && isEqual(variables, { personNum: 1, filmNum: 1 })) {
+        return complexResult;
+      }
+      throw new Error('Invalid Query');
+    });
+    fetchMock.post(missingUrl, () => {
+      throw new Error('Network error');
+    });
+
+    fetchMock.post(unauthorizedUrl, 403);
+    fetchMock.post(serviceUnavailableUrl, 503);
+  });
+
+  afterEach(fetchMock.reset);
+
+  it('should not throw with no arguments', () => {
+    assert.doesNotThrow(createApolloFetch);
+  });
+
+  it('should call fetch', (done) => {
+    const fetcher = createApolloFetch();
+    const result = fetcher({query: print(sampleQuery)});
+    result.then((response) => {
+      assert.deepEqual(fetchMock.calls('/graphql').length, 1);
+      assert.deepEqual(response, JSON.parse(data));
+      done();
+    });
+  });
+
+  it('should call fetch with correct url', (done) => {
+    const uri = 'test';
+    const fetcher = createApolloFetch({uri});
+    const result = fetcher({query: print(sampleQuery)});
+    result.then((response) => {
+      //correct response
+      assert.deepEqual(response, JSON.parse(data));
+      //single call
+      assert.deepEqual(fetchMock.calls(uri).length, 1);
+
+      assert.deepEqual(fetchMock.lastCall(uri)[0], uri);
+      const options = fetchMock.lastCall(uri)[1];
+      const body = JSON.parse(options.body);
+      assert.deepEqual(options.method, 'POST');
+      assert.deepEqual(options.headers, {Accept: '*/*', 'Content-Type': 'application/json'});
+      assert.deepEqual(body.query, print(sampleQuery));
+      done();
+    });
+  });
+
+  it('should pass an error onto the Promise', () => {
+    const uri = 'error';
+    const fetcher = createApolloFetch({uri, customFetch: fetch});
+    const result = fetcher({query: print(sampleQuery)});
+    return assert.isRejected(result, mockError.throws, mockError.throws.message);
+  });
+
+// missingUrl
+
+  it('should catch on a network error', (done) => {
+    const fetcher = createApolloFetch({uri: unauthorizedUrl});
+    const result = fetcher({query: print(sampleQuery)});
+    result.then(expect.fail)
+    .catch((error) => {
+      assert.deepEqual(error.message, 'Network request failed with status 403 - \"Forbidden\"');
+      assert.isDefined(error.response);
+      assert.isDefined(error.parseError);
+      done();
+    });
+  });
+
+  it('should return a fail to parse response when fetch returns raw response', (done) => {
+    const fetcher = createApolloFetch({uri: '/raw'});
+    const result = fetcher({query: print(sampleQuery)});
+    result.then(expect.fail)
+    .catch((error) => {
+      assert.deepEqual(error.message, 'Network request failed to return valid JSON');
+      assert.isDefined(error.response);
+      assert.isDefined(error.raw);
+      assert.deepEqual(error.raw, unparsableData);
+      done();
+    });
+  });
+
+
+  describe('middleware', () => {
+    it('should throw an error if you pass something bad', () => {
+      const malWare: any = {};
+      const networkInterface = createApolloFetch({ uri: '/graphql' });
+
+      try {
+        networkInterface.use([malWare]);
+        expect.fail();
+      } catch (error) {
+        assert.equal(
+          error.message,
+          'Middleware must implement the applyMiddleware function',
+        );
+      }
+
+    });
+
+    it('should take a middleware and assign it', () => {
+      const testWare = TestWare();
+
+      const networkInterface = createApolloFetch({ uri: '/graphql' });
+      networkInterface.use([testWare]);
+
+      assert.equal((<any>networkInterface)._middlewares[0], testWare);
+    });
+
+    it('should take more than one middleware and assign it', () => {
+      const testWare1 = TestWare();
+      const testWare2 = TestWare();
+
+      const networkInterface = createApolloFetch({ uri: '/graphql' });
+      networkInterface.use([testWare1, testWare2]);
+
+      assert.deepEqual((<any>networkInterface)._middlewares, [testWare1, testWare2]);
+    });
+
+    it('should alter the request variables', () => {
+      const testWare1 = TestWare([
+        { key: 'personNum', val: 1 },
+      ]);
+
+      const swapi = createApolloFetch({ uri: swapiUrl });
+      swapi.use([testWare1]);
+      // this is a stub for the end user client api
+      const simpleRequest = {
+        query: print(simpleQueryWithVar),
+        variables: {},
+        debugName: 'People query',
+      };
+
+      return assert.eventually.deepEqual(
+        swapi(simpleRequest),
+        simpleResult,
+      );
+    });
+
+    it('should alter the options', () => {
+      const testWare1 = TestWare([], [
+        { key: 'planet', val: 'mars' },
+      ]);
+
+      const swapi = createApolloFetch({ uri: swapiUrl });
+      swapi.use([testWare1]);
+      // this is a stub for the end user client api
+      const simpleRequest = {
+        query: print(simpleQueryWithNoVars),
+        variables: {},
+        debugName: 'People query',
+      };
+
+      return swapi(simpleRequest).then(() => {
+        assert.equal((fetchMock.lastCall()[1] as any).planet, 'mars');
+      });
+    });
+
+    it('should alter the request body params', () => {
+      const testWare1 = TestWare([], [], [
+        { key: 'newParam', val: '0123456789' },
+      ]);
+
+      const swapi = createApolloFetch({ uri: 'http://graphql-swapi.test/' });
+      swapi.use([testWare1]);
+      const simpleRequest = {
+        query: print(simpleQueryWithVar),
+        variables: { personNum: 1 },
+        debugName: 'People query',
+      };
+
+      return swapi(simpleRequest).then(() => {
+        return assert.deepEqual(
+          JSON.parse((fetchMock.lastCall()[1] as any).body),
+          {
+            query: 'query people($personNum: Int!) {\n  allPeople(first: $personNum) {\n    people {\n      name\n    }\n  }\n}\n',
+            variables: { personNum: 1 },
+            debugName: 'People query',
+            newParam: '0123456789',
+          },
+        );
+      });
+    });
+
+    it('handle multiple middlewares', () => {
+      const testWare1 = TestWare([
+        { key: 'personNum', val: 1 },
+      ]);
+      const testWare2 = TestWare([
+        { key: 'filmNum', val: 1 },
+      ]);
+
+      const swapi = createApolloFetch({ uri: 'http://graphql-swapi.test/' });
+      swapi.use([testWare1, testWare2]);
+      // this is a stub for the end user client api
+      const simpleRequest = {
+        query: print(complexQueryWithTwoVars),
+        variables: {},
+        debugName: 'People query',
+      };
+
+      return assert.eventually.deepEqual(
+        swapi(simpleRequest),
+        complexResult,
+      );
+    });
+
+    it('should chain use() calls', () => {
+      const testWare1 = TestWare([
+        { key: 'personNum', val: 1 },
+      ]);
+      const testWare2 = TestWare([
+        { key: 'filmNum', val: 1 },
+      ]);
+
+      const swapi = createApolloFetch({ uri: swapiUrl });
+      swapi.use([testWare1])
+        .use([testWare2]);
+      const simpleRequest = {
+        query: print(complexQueryWithTwoVars),
+        variables: {},
+        debugName: 'People query',
+      };
+
+      return assert.eventually.deepEqual(
+        swapi(simpleRequest),
+        complexResult,
+      );
+    });
+
+    it('should chain use() and useAfter() calls', () => {
+      const testWare1 = TestWare();
+      const testWare2 = TestAfterWare();
+
+      const networkInterface = createApolloFetch({ uri: swapiUrl });
+      networkInterface.use([testWare1])
+        .useAfter([testWare2]);
+      assert.deepEqual((<any>networkInterface)._middlewares, [testWare1]);
+      assert.deepEqual((<any>networkInterface)._afterwares, [testWare2]);
+    });
+
+  });
+
+  describe('afterware', () => {
+    it('should return errors thrown in afterwares', () => {
+      const networkInterface = createApolloFetch({ uri: swapiUrl });
+      networkInterface.useAfter([{
+        applyAfterware() {
+          throw Error('Afterware error');
+        },
+      }]);
+
+      const simpleRequest = {
+        query: print(simpleQueryWithNoVars),
+        variables: {},
+        debugName: 'People query',
+      };
+
+      return assert.isRejected(
+        networkInterface(simpleRequest),
+        Error,
+        'Afterware error',
+      );
+    });
+    it('should throw an error if you pass something bad', () => {
+      const malWare = TestAfterWare();
+      delete malWare.applyAfterware;
+      const networkInterface = createApolloFetch({ uri: '/graphql' });
+
+      try {
+        networkInterface.useAfter([malWare]);
+        expect.fail();
+      } catch (error) {
+        assert.equal(
+          error.message,
+          'Afterware must implement the applyAfterware function',
+        );
+      }
+
+    });
+
+    it('should take a afterware and assign it', () => {
+      const testWare = TestAfterWare();
+
+      const networkInterface = createApolloFetch({ uri: '/graphql' });
+      networkInterface.useAfter([testWare]);
+
+      assert.equal((<any>networkInterface)._afterwares[0], testWare);
+    });
+
+    it('should take more than one afterware and assign it', () => {
+      const testWare1 = TestAfterWare();
+      const testWare2 = TestAfterWare();
+
+      const networkInterface = createApolloFetch({ uri: '/graphql' });
+      networkInterface.useAfter([testWare1, testWare2]);
+
+      assert.deepEqual((<any>networkInterface)._afterwares, [testWare1, testWare2]);
+    });
+
+    it('should chain useAfter() calls', () => {
+      const testWare1 = TestAfterWare();
+      const testWare2 = TestAfterWare();
+
+      const networkInterface = createApolloFetch({ uri: '/graphql' });
+      networkInterface.useAfter([testWare1])
+        .useAfter([testWare2]);
+
+      assert.deepEqual((<any>networkInterface)._afterwares, [testWare1, testWare2]);
+    });
+
+    it('should chain useAfter() and use() calls', () => {
+      const testWare1 = TestAfterWare();
+      const testWare2 = TestWare();
+
+      const networkInterface = createApolloFetch({ uri: swapiUrl });
+      networkInterface.useAfter([testWare1])
+        .use([testWare2]);
+      assert.deepEqual((<any>networkInterface)._middlewares, [testWare2]);
+      assert.deepEqual((<any>networkInterface)._afterwares, [testWare1]);
+    });
+
+  });
+
+});
+
+// simulate middleware by altering variables and options
+function TestWare(
+  variables: Array<{ key: string, val: any }> = [],
+  options: Array<{ key: string, val: any }> = [],
+  bodyParams: Array<{ key: string, val: any }> = [],
+) {
+
+  return {
+    applyMiddleware: (request: RequestAndOptions, next: Function): void => {
+      variables.map((variable) => {
+        (<any>request.request.variables)[variable.key] = variable.val;
+      });
+
+      options.map((variable) => {
+        (<any>request.options)[variable.key] = variable.val;
+      });
+
+      bodyParams.map((param) => {
+        request.request[param.key as string] = param.val;
+      });
+
+      next();
+    },
+  };
+}
+
+// simulate afterware by altering variables and options
+function TestAfterWare(
+  options: Array<{ key: string, val: any }> = [],
+) {
+
+  return {
+    applyAfterware: (response: ResponseAndOptions, next: Function): void => {
+      options.map((variable) => {
+        (<any>response.options)[variable.key] = variable.val;
+      });
+
+      next();
+    },
+  };
+}

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -1,0 +1,1 @@
+import './apollo-fetch';


### PR DESCRIPTION
This is the initial release of apollo-fetch, the lightweight client for GraphQL requests that supports middleware and afterware.
