### PR TITLE
Enable file uploads via mutation or query input variables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNEXT
 
-Files can now be uploaded via mutation or query input variables, implementing the [`apollo-upload-client`](https://github.com/jaydenseric/apollo-upload-client) multipart request method. Setup [`apollo-upload-server`](https://github.com/jaydenseric/apollo-upload-server) to use this feature until support is added to [`graphql-server`](https://github.com/apollographql/graphql-server). Fixed [#6](https://github.com/apollographql/apollo-fetch/issues/6).
+Files can now be uploaded via mutation or query input variables, implementing the [`apollo-upload-client`](https://github.com/jaydenseric/apollo-upload-client) multipart request method. Setup [`apollo-upload-server`](https://github.com/jaydenseric/apollo-upload-server) to use this feature until support is added to [`graphql-server`](https://github.com/apollographql/graphql-server). Fixed [#6](https://github.com/apollographql/apollo-fetch/issues/6) via [#8](https://github.com/apollographql/apollo-fetch/pull/8).
 
 ### 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+Files can now be uploaded via mutation or query input variables, implementing the [`apollo-upload-client`](https://github.com/jaydenseric/apollo-upload-client) multipart request method. Setup [`apollo-upload-server`](https://github.com/jaydenseric/apollo-upload-server) to use this feature until support is added to [`graphql-server`](https://github.com/apollographql/graphql-server). Fixed [#6](https://github.com/apollographql/apollo-fetch/issues/6).
+
 ### 0.3.0
 
 Changes the middleware and afterware to accept functions instead of objects

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "Evans Hauser <evanshauser@gmail.com>",
   "contributors": [
     "Jonas Helfer <jonas@helfer.email>",
-    "Sashko Stubailo <sashko@stubailo.com>"
+    "Sashko Stubailo <sashko@stubailo.com>",
+    "Jayden Seric <me@jaydenseric.com>"
   ],
   "license": "MIT",
   "main": "./dist/src/index.js",
@@ -36,6 +37,7 @@
     "prepublishOnly": "npm run clean && npm run build"
   },
   "dependencies": {
+    "extract-files": "^1.1.0",
     "isomorphic-fetch": "^2.2.1"
   },
   "devDependencies": {

--- a/tests/apollo-fetch.ts
+++ b/tests/apollo-fetch.ts
@@ -179,7 +179,7 @@ describe('apollo-fetch', () => {
       const options = fetchMock.lastCall(uri)[1];
       const body = JSON.parse(options.body);
       assert.deepEqual(options.method, 'POST');
-      assert.deepEqual(options.headers, {Accept: '*/*', 'Content-Type': 'application/json'});
+      assert.deepEqual(options.headers, {'Content-Type': 'application/json'});
       assert.deepEqual(body.query, print(sampleQuery));
     });
 


### PR DESCRIPTION
Files can now be uploaded via mutation or query input variables, implementing the [`apollo-upload-client`](https://github.com/jaydenseric/apollo-upload-client) multipart request method. Users must setup [`apollo-upload-server`](https://github.com/jaydenseric/apollo-upload-server) to use this feature until support is added to [`graphql-server`](https://github.com/apollographql/graphql-server). An unmodified API server will continue to work fine if users don't attempt uploads.

You can try it out by cloning the [apollo-upload-examples `fetch` branch](https://github.com/jaydenseric/apollo-upload-examples/tree/apollo-fetch). Use `npm link` to try it out with this PR.

Fixes https://github.com/apollographql/apollo-fetch/issues/6.

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
