### PR TITLE
UMD support

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,9 @@
-dist/tests/
 src/
 tests/
 .travis.yml
+rollup.config.js
 tsconfig.json
+tsconfig.base.json
+tsconfig.test.json
 tslint.json
 typings.d.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+- Adds support for UMD and ES2015 modules (tree-shaking) [PR #9](https://github.com/apollographql/apollo-fetch/pull/9)
+
 ### 0.5.0
 
 - Export all TypeScript types. [PR #13](https://github.com/apollographql/apollo-fetch/pull/13)

--- a/packages/apollo-fetch/package.json
+++ b/packages/apollo-fetch/package.json
@@ -6,11 +6,14 @@
   "contributors": [
     "Jonas Helfer <jonas@helfer.email>",
     "Sashko Stubailo <sashko@stubailo.com>",
-    "Jayden Seric <me@jaydenseric.com>"
+    "Jayden Seric <me@jaydenseric.com>",
+    "Kamil Kisiela <kamil.kisiela@gmail.com>"
   ],
   "license": "MIT",
-  "main": "./dist/src/index.js",
-  "typings": "./dist/src/index.d.ts",
+  "main": "./dist/bundle.umd.js",
+  "module": "./dist/index.js",
+  "jsnext:main": "./dist/index.js",
+  "typings": "./dist/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/apollographql/apollo-fetch/tree/master/packages/apollo-fetch"
@@ -20,16 +23,20 @@
   },
   "homepage": "https://github.com/apollographql/apollo-fetch#readme",
   "scripts": {
-    "pretest": "npm run build",
+    "pretest": "npm run build-test",
     "test": "npm run test-only --",
     "posttest": "npm run lint",
     "test-only": "mocha --reporter spec --full-trace dist/tests/tests.js",
     "test-watch": "mocha --reporter spec --full-trace dist/tests/tests.js --watch",
     "coverage:test": "_mocha --reporter dot --full-trace dist/tests/tests.js",
     "coverage": "nyc --reporter=lcov npm run coverage:test",
-    "lint": "tslint --type-check -p tsconfig.json src/*.ts && tslint --type-check -p tsconfig.json tests/*.ts",
+    "lint": "tslint --type-check -p tsconfig.test.json src/*.ts && tslint --type-check -p tsconfig.test.json tests/*.ts",
     "prebuild": "npm run clean:dist",
+    "prebuild-test": "npm run clean:dist",
     "build": "tsc",
+    "build-test": "tsc -p tsconfig.test.json",
+    "postbuild": "npm run bundle",
+    "bundle": "rollup -c",
     "watch": "tsc -w",
     "clean": "npm run clean:dist && npm run clean:coverage",
     "clean:dist": "rimraf dist/*",
@@ -53,6 +60,7 @@
     "mocha": "^3.2.0",
     "nyc": "^11.0.3",
     "rimraf": "^2.5.4",
+    "rollup": "^0.45.2",
     "sinon": "^2.3.4",
     "source-map-support": "^0.4.5",
     "tslint": "^5.0.0",

--- a/packages/apollo-fetch/rollup.config.js
+++ b/packages/apollo-fetch/rollup.config.js
@@ -1,0 +1,18 @@
+export default {
+  entry: 'dist/index.js',
+  dest: 'dist/bundle.umd.js',
+  format: 'umd',
+  moduleName: 'apolloFetch',
+  onwarn
+};
+
+function onwarn(message) {
+  const suppressed = [
+    'UNRESOLVED_IMPORT',
+    'THIS_IS_UNDEFINED'
+  ];
+
+  if (!suppressed.find(code => message.code === code)) {
+    return console.warn(message.message);
+  }
+}

--- a/packages/apollo-fetch/tsconfig.base.json
+++ b/packages/apollo-fetch/tsconfig.base.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["es6", "dom"],
+    "module": "es2015",
+    "moduleResolution": "node",
+    "removeComments": true,
+    "sourceMap": true,
+    "declaration": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "noImplicitAny": false,
+    "noUnusedParameters": false,
+    "noUnusedLocals": true,
+    "skipLibCheck": true
+  }
+}

--- a/packages/apollo-fetch/tsconfig.json
+++ b/packages/apollo-fetch/tsconfig.json
@@ -1,21 +1,6 @@
 {
-  "compilerOptions": {
-    "target": "es5",
-    "lib": ["es6", "dom"],
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "removeComments": true,
-    "sourceMap": true,
-    "declaration": true,
-    "rootDir": ".",
-    "outDir": "dist",
-    "noImplicitAny": false,
-    "noUnusedParameters": false,
-    "noUnusedLocals": true,
-    "skipLibCheck": true
-  },
+  "extends": "./tsconfig.base",
   "include": [
-    "src/**/*.ts",
-    "tests/**/*.ts"
+    "src/**/*.ts"
   ]
 }

--- a/packages/apollo-fetch/tsconfig.test.json
+++ b/packages/apollo-fetch/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.base",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": "."
+  },
+  "include": [
+    "src/**/*.ts",
+    "tests/**/*.ts"
+  ]
+}


### PR DESCRIPTION
Fixes #3

Use `/src` as the root directory. No more `/dist/src/index.js`, just `/dist/index.js`.
Create `/dist/bundle.umd.js`
Use `module`, `jsnext:main` for `/dist/index.js`
Use `main` for `/dist/bundle.umd.js`

Fix shadow variable `apolloFetch` in `/src/apollo-fetch.ts`