### PR TITLE
apollo-fetch-upload v1.1.0

### DIFF
--- a/packages/apollo-fetch-upload/changelog.md
+++ b/packages/apollo-fetch-upload/changelog.md
@@ -1,5 +1,9 @@
 # apollo-fetch-upload change log
 
+## next
+
+Added several subheadings to the readme, fixing some broken links.
+
 ## 1.0.1
 
 Added a readme, via [#33](https://github.com/apollographql/apollo-fetch/pull/33).

--- a/packages/apollo-fetch-upload/changelog.md
+++ b/packages/apollo-fetch-upload/changelog.md
@@ -2,11 +2,12 @@
 
 ## next
 
-Added several subheadings to the readme, fixing some broken links.
+- Updated `apollo-fetch` dependency.
+- Added several subheadings to the readme, fixing some broken links.
 
 ## 1.0.1
 
-Added a readme, via [#33](https://github.com/apollographql/apollo-fetch/pull/33).
+- Added a readme, via [#33](https://github.com/apollographql/apollo-fetch/pull/33).
 
 ## 1.0.0
 

--- a/packages/apollo-fetch-upload/changelog.md
+++ b/packages/apollo-fetch-upload/changelog.md
@@ -1,6 +1,6 @@
 # apollo-fetch-upload change log
 
-## next
+## 1.1.0
 
 - Updated `apollo-fetch` dependency.
 - Added several subheadings to the readme, fixing some broken links.

--- a/packages/apollo-fetch-upload/package.json
+++ b/packages/apollo-fetch-upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-fetch-upload",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Allows files to be used in GraphQL requests with apollo-fetch.",
   "license": "MIT",
   "author": "Jayden Seric <me@jaydenseric.com>",

--- a/packages/apollo-fetch-upload/package.json
+++ b/packages/apollo-fetch-upload/package.json
@@ -30,7 +30,7 @@
     "test": "ava test/dist/test"
   },
   "dependencies": {
-    "apollo-fetch": "^0.5.2",
+    "apollo-fetch": "^0.6.0",
     "extract-files": "^2.0.1"
   },
   "devDependencies": {

--- a/packages/apollo-fetch-upload/readme.md
+++ b/packages/apollo-fetch-upload/readme.md
@@ -61,7 +61,7 @@ See also the [setup instructions](https://github.com/jaydenseric/apollo-upload-s
 
 Use [`File`](https://developer.mozilla.org/en/docs/Web/API/File), [`FileList`](https://developer.mozilla.org/en/docs/Web/API/FileList) or [`ReactNativeFile`](#react-native) instances anywhere within mutation or query input variables. For server instructions see [`apollo-upload-server`](https://github.com/jaydenseric/apollo-upload-server). Checkout the [example API and client](https://github.com/jaydenseric/apollo-upload-examples).
 
-[`File`](https://developer.mozilla.org/en/docs/Web/API/File) example:
+### [`File`](https://developer.mozilla.org/en/docs/Web/API/File) example
 
 ```jsx
 import { graphql, gql } from 'react-apollo'
@@ -87,7 +87,7 @@ export default graphql(gql`
 `)(UploadFile)
 ```
 
-[`FileList`](https://developer.mozilla.org/en/docs/Web/API/FileList) example:
+### [`FileList`](https://developer.mozilla.org/en/docs/Web/API/FileList) example
 
 ```jsx
 import { graphql, gql } from 'react-apollo'
@@ -113,7 +113,9 @@ export default graphql(gql`
 `)(UploadFiles)
 ```
 
-For React Native, substitute [`File`](https://developer.mozilla.org/en/docs/Web/API/File) with `ReactNativeFile` from [`extract-files`](https://github.com/jaydenseric/extract-files):
+### React Native
+
+Substitute [`File`](https://developer.mozilla.org/en/docs/Web/API/File) with `ReactNativeFile` from [`extract-files`](https://github.com/jaydenseric/extract-files):
 
 ```js
 import { ReactNativeFile } from 'apollo-fetch-upload'


### PR DESCRIPTION
- Updated `apollo-fetch` dependency.
- Added several subheadings to the readme, fixing some broken links.