### PR TITLE
Dropped dependency isomorphic-fetch in favor of cross-fetch (React Native compatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 `apollo-fetch` is a lightweight client for GraphQL requests that supports middleware and afterware that modify requests and responses.
 
-By default `apollo-fetch` uses `isomorphic-fetch`, but you have the option of using a custom fetch function.
+By default `apollo-fetch` uses `cross-fetch`, but you have the option of using a custom fetch function.
 
 If you are interested in contributing, please read the [documentation on repository structure](docs/monorepo.md) and [Contributor Guide](CONTRIBUTING.md).
 
@@ -290,7 +290,7 @@ FetchOptions {
 /*
  * defaults:
  * uri = '/graphql'
- * customFetch = fetch from isomorphic-fetch
+ * customFetch = fetch from cross-fetch
  * constructOptions = constructDefaultOptions(exported from apollo-fetch)
  */
 ```

--- a/packages/apollo-fetch/package.json
+++ b/packages/apollo-fetch/package.json
@@ -49,7 +49,7 @@
     "prepublishOnly": "npm run clean && npm run build"
   },
   "dependencies": {
-    "isomorphic-fetch": "^2.2.1"
+    "cross-fetch": "^1.0.0"
   },
   "devDependencies": {
     "@types/chai": "4.0.4",

--- a/packages/apollo-fetch/src/apollo-fetch.ts
+++ b/packages/apollo-fetch/src/apollo-fetch.ts
@@ -14,7 +14,7 @@ import {
   FetchError,
   BatchError,
 } from './types';
-import 'isomorphic-fetch';
+import 'cross-fetch/polyfill';
 
 type WareStack =
   | MiddlewareInterface[]


### PR DESCRIPTION
[isomorphic-fetch](https://github.com/matthew-andrews/isomorphic-fetch) has a bug that prevents it from running in a react native environment. Since it is no longer maintained, it will never be fixed. That also means dependencies are outdated. [cross-fetch](https://github.com/lquixada/cross-fetch) is React Native compatible.