### PR TITLE
docs(types): Add context to GraphQLRequest type

### DIFF
--- a/packages/apollo-fetch/src/types.ts
+++ b/packages/apollo-fetch/src/types.ts
@@ -11,6 +11,7 @@ export interface GraphQLRequest {
   query?: string;
   variables?: object;
   operationName?: string;
+  context?: any;
 }
 
 export interface FetchResult {


### PR DESCRIPTION
- Adding context to `GraphQLRequest` type so we can properly use context inside middleware:

```
const middleware = ({ request, options }, next) => {
  // Here request.context is not available in TS as request is of type GraphQLRequest
  next();
};
```