### PR TITLE
Include a note about gql in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ const apolloFetch = createApolloFetch({ uri });
 apolloFetch({ query, variables }).then(...).catch(...);
 ```
 
+Note that apollo-fetch does not support `gql` from the graphql-tag library. Leave `gql` out when writing queries that are used with apollo-fetch, or use `print` from the graphql library to stringify the query.
+
 ### Middleware
 
 A GraphQL mutation with authentication middleware.


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

This PR adds a notice about the `gql` template tag to the README. graphql-tag is widely used in Apollo projects and the fact that Apollo-fetch does not support it might come as a surprise to users.

Related issue: https://github.com/apollographql/apollo-fetch/issues/69